### PR TITLE
CI: pull_request_target

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,4 +1,4 @@
-on: [pull_request]
+on: [pull_request_target]
 
 name: benchmark pull requests
 jobs:


### PR DESCRIPTION
This PR should allow the benchmarking bot to report benchmark diff's from PR's made by forked repos.

It fixes the problem reported in: https://github.com/nikkolasg/snarkpack/pull/8#issuecomment-1581341681 with the solution found in: https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/