### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/commitment.rs
+++ b/src/commitment.rs
@@ -86,7 +86,7 @@ where
             })
             .unzip();
 
-        Ok(Self { a: a, b: b })
+        Ok(Self { a, b })
     }
 
     /// Returns the left and right commitment key part. It makes copy.
@@ -128,7 +128,7 @@ where
             })
             .unzip();
 
-        Ok(Self { a: a, b: b })
+        Ok(Self { a, b })
     }
 
     /// Returns the first values in the vector of v1 and v2 (respectively

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ pub(crate) fn compress<C: AffineRepr>(vec: &mut Vec<C>, split: usize, scaler: &C
         .zip(right.par_iter())
         .for_each(|(a_l, a_r)| {
             //let mut x = mul!(a_r.into_group(), scaler.clone());
-            let sc = scaler.clone();
+            let sc = *scaler;
             let mut x = a_r.mul(sc);
             x.add_assign(*a_l);
             *a_l = x.into_affine();

--- a/src/pairing_check.rs
+++ b/src/pairing_check.rs
@@ -18,7 +18,7 @@ use std::ops::MulAssign;
 /// before going into a final exponentiation result
 /// - a right side result which is already in the right subgroup Gt which is to
 /// be compared to the left side when "final_exponentiatiat"-ed
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Default)]
 pub struct PairingCheck<E: Pairing> {
     left: <E as Pairing>::TargetField,
     right: <E as Pairing>::TargetField,

--- a/src/pairing_check.rs
+++ b/src/pairing_check.rs
@@ -109,20 +109,14 @@ where
                 (E::G1Prepared::from(na), E::G2Prepared::from(**b))
             })
             .map(|(a, b)| E::miller_loop(a, b))
-            .fold(
-                || <E as Pairing>::TargetField::one(),
-                |mut acc, res| {
-                    acc.mul_assign(&(res.0));
-                    acc
-                },
-            )
-            .reduce(
-                || <E as Pairing>::TargetField::one(),
-                |mut acc, res| {
-                    acc.mul_assign(&res);
-                    acc
-                },
-            );
+            .fold(<E as Pairing>::TargetField::one, |mut acc, res| {
+                acc.mul_assign(&(res.0));
+                acc
+            })
+            .reduce(<E as Pairing>::TargetField::one, |mut acc, res| {
+                acc.mul_assign(&res);
+                acc
+            });
         let mut outt = out.clone();
         if out != &<E as Pairing>::TargetField::one() {
             // we only need to make this expensive operation is the output is

--- a/src/pairing_check.rs
+++ b/src/pairing_check.rs
@@ -101,7 +101,7 @@ where
         it: &[(&'a E::G1Affine, &'a E::G2Affine)],
         out: &'a <E as Pairing>::TargetField,
     ) -> PairingCheck<E> {
-        let coeff = rand_fr::<E, R>(&rng);
+        let coeff = rand_fr::<E, R>(rng);
         let miller_out = it
             .into_par_iter()
             .map(|(a, b)| {
@@ -127,7 +127,7 @@ where
         if out != &<E as Pairing>::TargetField::one() {
             // we only need to make this expensive operation is the output is
             // not one since 1^r = 1
-            outt = outt.pow(&(coeff.into_bigint()));
+            outt = outt.pow(coeff.into_bigint());
         }
         PairingCheck {
             left: miller_out,

--- a/src/pairing_check.rs
+++ b/src/pairing_check.rs
@@ -117,7 +117,7 @@ where
                 acc.mul_assign(&res);
                 acc
             });
-        let mut outt = out.clone();
+        let mut outt = *out;
         if out != &<E as Pairing>::TargetField::one() {
             // we only need to make this expensive operation is the output is
             // not one since 1^r = 1
@@ -171,7 +171,7 @@ fn mul_if_not_one<E: Pairing>(
 ) {
     let one = <E as Pairing>::TargetField::one();
     if left == &one {
-        *left = right.clone();
+        *left = *right;
         return;
     } else if right == &one {
         // nothing to do here

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -74,7 +74,7 @@ impl<E: Pairing> AggregateProof<E> {
     /// `CanonicalSerialize`.
     pub fn write<W: Write>(&self, mut out: W) -> Result<(), Error> {
         self.serialize_compressed(&mut out)
-            .map_err(|e| Error::Serialization(e))
+            .map_err(Error::Serialization)
     }
 
     /// Reads the aggregate proof to the given destination. This method is for
@@ -82,7 +82,7 @@ impl<E: Pairing> AggregateProof<E> {
     /// another arkwork protocol, you can use the underlying implementation of
     /// `CanonicalSerialize`.
     pub fn read<R: Read>(mut source: R) -> Result<Self, Error> {
-        Self::deserialize_compressed(&mut source).map_err(|e| Error::Serialization(e))
+        Self::deserialize_compressed(&mut source).map_err(Error::Serialization)
     }
 }
 
@@ -135,7 +135,7 @@ impl<E: Pairing> GipaProof<E> {
 impl<E: Pairing> CanonicalSerialize for GipaProof<E> {
     fn serialized_size(&self, compress: Compress) -> usize {
         let log_proofs = Self::log_proofs(self.nproofs as usize);
-        (self.nproofs as u32).serialized_size(compress)
+        self.nproofs.serialized_size(compress)
             + log_proofs
                 * (self.comms_ab[0].0.serialized_size(compress)
                     + self.comms_ab[0].1.serialized_size(compress)

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -93,14 +93,8 @@ type CommitmentOutput<E> = commitment::Output<<E as Pairing>::TargetField>;
 #[derive(Debug, Clone)]
 pub struct GipaProof<E: Pairing> {
     pub nproofs: u32,
-    pub comms_ab: Vec<(
-        CommitmentOutput<E>,
-        CommitmentOutput<E>,
-    )>,
-    pub comms_c: Vec<(
-        CommitmentOutput<E>,
-        CommitmentOutput<E>,
-    )>,
+    pub comms_ab: Vec<(CommitmentOutput<E>, CommitmentOutput<E>)>,
+    pub comms_c: Vec<(CommitmentOutput<E>, CommitmentOutput<E>)>,
     pub z_ab: Vec<(<E as Pairing>::TargetField, <E as Pairing>::TargetField)>,
     pub z_c: Vec<(E::G1Affine, E::G1Affine)>,
     pub final_a: E::G1Affine,

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -89,16 +89,17 @@ impl<E: Pairing> AggregateProof<E> {
 /// It contains all elements derived in the GIPA loop for both TIPP and MIPP at
 /// the same time. Serialization is done manually here for better inspection
 /// (CanonicalSerialization is implemented manually, not via the macro).
+type CommitmentOutput<E> = commitment::Output<<E as Pairing>::TargetField>;
 #[derive(Debug, Clone)]
 pub struct GipaProof<E: Pairing> {
     pub nproofs: u32,
     pub comms_ab: Vec<(
-        commitment::Output<<E as Pairing>::TargetField>,
-        commitment::Output<<E as Pairing>::TargetField>,
+        CommitmentOutput<E>,
+        CommitmentOutput<E>,
     )>,
     pub comms_c: Vec<(
-        commitment::Output<<E as Pairing>::TargetField>,
-        commitment::Output<<E as Pairing>::TargetField>,
+        CommitmentOutput<E>,
+        CommitmentOutput<E>,
     )>,
     pub z_ab: Vec<(<E as Pairing>::TargetField, <E as Pairing>::TargetField)>,
     pub z_c: Vec<(E::G1Affine, E::G1Affine)>,

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -83,7 +83,7 @@ pub fn aggregate_proofs<E: Pairing + std::fmt::Debug, T: Transcript>(
     let b_r = b
         .par_iter()
         .zip(r_vec.par_iter())
-        .map(|(bi, ri)| mul!(bi.into_group(), ri.clone()).into_affine())
+        .map(|(bi, ri)| mul!(bi.into_group(), *ri).into_affine())
         .collect::<Vec<_>>();
 
     let refb_r = &b_r;
@@ -130,6 +130,7 @@ pub fn aggregate_proofs<E: Pairing + std::fmt::Debug, T: Transcript>(
 /// commitment key v is used to commit to A and C recursively in GIPA such that
 /// only one KZG proof is needed for v. In the original paper version, since the
 /// challenges of GIPA would be different, two KZG proofs would be needed.
+#[allow(clippy::too_many_arguments)]
 fn prove_tipp_mipp<E: Pairing, T: Transcript>(
     srs: &ProverSRS<E>,
     transcript: &mut T,
@@ -141,7 +142,7 @@ fn prove_tipp_mipp<E: Pairing, T: Transcript>(
     ip_ab: &<E as Pairing>::TargetField,
     agg_c: &E::G1Affine,
 ) -> Result<TippMippProof<E>, Error> {
-    let r_shift = r_vec[1].clone();
+    let r_shift = r_vec[1];
     // Run GIPA
     let (proof, mut challenges, mut challenges_inv) =
         gipa_tipp_mipp(transcript, a, b, c, &srs.vkey, wkey, r_vec, ip_ab, agg_c)?;
@@ -189,6 +190,8 @@ fn prove_tipp_mipp<E: Pairing, T: Transcript>(
 /// It returns a proof containing all intermdiate committed values, as well as
 /// the challenges generated necessary to do the polynomial commitment proof
 /// later in TIPP.
+#[allow(clippy::too_many_arguments)]
+#[allow(clippy::type_complexity)]
 fn gipa_tipp_mipp<E: Pairing>(
     transcript: &mut impl Transcript,
     a: &[E::G1Affine],
@@ -304,7 +307,7 @@ fn gipa_tipp_mipp<E: Pairing>(
             .for_each(|(r_l, r_r)| {
                 // r[:n'] + r[n':]^x^-1
                 r_r.mul_assign(&c_inv);
-                r_l.add_assign(r_r.clone());
+                r_l.add_assign(*r_r);
             });
         let len = r_left.len();
         m_r.resize(len, E::ScalarField::zero()); // shrink to new size

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -90,9 +90,9 @@ pub fn aggregate_proofs<E: Pairing + std::fmt::Debug, T: Transcript>(
     let refr_vec = &r_vec;
     try_par! {
         // compute A * B^r for the verifier
-        let ip_ab = ip::pairing::<E>(&refa, &refb_r),
+        let ip_ab = ip::pairing::<E>(refa, refb_r),
         // compute C^r for the verifier
-        let agg_c = ip::multiexponentiation::<E::G1Affine>(&refc, &refr_vec)
+        let agg_c = ip::multiexponentiation::<E::G1Affine>(refc, refr_vec)
     };
     let agg_c = agg_c.into_affine();
     // w^{r^{-1}}
@@ -100,7 +100,7 @@ pub fn aggregate_proofs<E: Pairing + std::fmt::Debug, T: Transcript>(
 
     // we prove tipp and mipp using the same recursive loop
     let proof = prove_tipp_mipp(
-        &srs,
+        srs,
         transcript,
         &a,
         &b_r,
@@ -144,7 +144,7 @@ fn prove_tipp_mipp<E: Pairing, T: Transcript>(
     let r_shift = r_vec[1].clone();
     // Run GIPA
     let (proof, mut challenges, mut challenges_inv) =
-        gipa_tipp_mipp(transcript, a, b, c, &srs.vkey, &wkey, r_vec, ip_ab, agg_c)?;
+        gipa_tipp_mipp(transcript, a, b, c, &srs.vkey, wkey, r_vec, ip_ab, agg_c)?;
 
     // Prove final commitment keys are wellformed
     // we reverse the transcript so the polynomial in kzg opening is constructed
@@ -251,11 +251,11 @@ fn gipa_tipp_mipp<E: Pairing>(
         // See section 3.3 for paper version with equivalent names
         try_par! {
             // TIPP part
-            let tab_l = commitment::pair::<E>(&rvk_left, &rwk_right, &ra_right, &rb_left),
-            let tab_r = commitment::pair::<E>(&rvk_right, &rwk_left, &ra_left, &rb_right),
+            let tab_l = commitment::pair::<E>(rvk_left, rwk_right, ra_right, rb_left),
+            let tab_r = commitment::pair::<E>(rvk_right, rwk_left, ra_left, rb_right),
             // \prod e(A_right,B_left)
-            let zab_l = ip::pairing::<E>(&ra_right, &rb_left),
-            let zab_r = ip::pairing::<E>(&ra_left, &rb_right),
+            let zab_l = ip::pairing::<E>(ra_right, rb_left),
+            let zab_r = ip::pairing::<E>(ra_left, rb_right),
 
             // MIPP part
             // z_l = c[n':] ^ r[:n']
@@ -263,9 +263,9 @@ fn gipa_tipp_mipp<E: Pairing>(
             // Z_r = c[:n'] ^ r[n':]
             let zc_r = ip::multiexponentiation::<E::G1Affine>(rc_left, rr_right),
             // u_l = c[n':] * v[:n']
-            let tuc_l = commitment::single_g1::<E>(&rvk_left, rc_right),
+            let tuc_l = commitment::single_g1::<E>(rvk_left, rc_right),
             // u_r = c[:n'] * v[n':]
-            let tuc_r = commitment::single_g1::<E>(&rvk_right, rc_left)
+            let tuc_r = commitment::single_g1::<E>(rvk_right, rc_left)
         };
 
         // Fiat-Shamir challenge
@@ -363,7 +363,7 @@ fn prove_commitment_v<G: AffineRepr>(
 
     // f_v(z)
     let vkey_poly_z = polynomial_evaluation_product_form_from_transcript(
-        &transcript,
+        transcript,
         kzg_challenge,
         &G::ScalarField::one(),
     );
@@ -393,9 +393,9 @@ fn prove_commitment_w<G: AffineRepr>(
 
     par! {
         // this computes f(z)
-        let fz = polynomial_evaluation_product_form_from_transcript(&transcript, kzg_challenge, &r_shift),
+        let fz = polynomial_evaluation_product_form_from_transcript(transcript, kzg_challenge, r_shift),
         // this computes the "shift" z^n
-        let zn = kzg_challenge.pow(&[n as u64])
+        let zn = kzg_challenge.pow([n as u64])
     };
     // this computes f_w(z) by multiplying by zn
     let mut fwz = fz;
@@ -455,11 +455,11 @@ fn create_kzg_opening<G: AffineRepr>(
     // of Bunz'19
     let (a, b) = rayon::join(
         || {
-            VariableBaseMSM::msm(&srs_powers_alpha_table, &quotient_polynomial_coeffs)
+            VariableBaseMSM::msm(srs_powers_alpha_table, &quotient_polynomial_coeffs)
                 .expect("msm for a failed!")
         },
         || {
-            VariableBaseMSM::msm(&srs_powers_beta_table, &quotient_polynomial_coeffs)
+            VariableBaseMSM::msm(srs_powers_beta_table, &quotient_polynomial_coeffs)
                 .expect("msm for b failed!")
         },
     );
@@ -482,10 +482,10 @@ pub(super) fn polynomial_evaluation_product_form_from_transcript<F: Field>(
 
     let one = F::one();
 
-    let mut res = one + transcript[0] * &power_zr;
+    let mut res = one + transcript[0] * power_zr;
     for x in &transcript[1..] {
         power_zr = power_zr.square();
-        res.mul_assign(one + *x * &power_zr);
+        res.mul_assign(one + *x * power_zr);
     }
 
     res
@@ -514,7 +514,7 @@ fn polynomial_coefficients_from_transcript<F: Field>(transcript: &[F], r_shift: 
             power_2_r = power_2_r.square();
         }
         for j in 0..n {
-            let coeff = coefficients[j] * &(*x * &power_2_r);
+            let coeff = coefficients[j] * (*x * power_2_r);
             coefficients.push(coeff);
         }
     }

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -423,14 +423,11 @@ fn create_kzg_opening<G: AffineRepr>(
     neg_kzg_challenge = neg_kzg_challenge.neg();
 
     if poly.coeffs().len() != srs_powers_alpha_table.len() {
-        return Err(Error::InvalidSRS(
-            format!(
-                "SRS len {} != coefficients len {}",
-                srs_powers_alpha_table.len(),
-                poly.coeffs().len(),
-            )
-            .to_string(),
-        ));
+        return Err(Error::InvalidSRS(format!(
+            "SRS len {} != coefficients len {}",
+            srs_powers_alpha_table.len(),
+            poly.coeffs().len(),
+        )));
     }
 
     // f_v(X) - f_v(z) / (X - z)

--- a/src/srs.rs
+++ b/src/srs.rs
@@ -163,7 +163,7 @@ impl<E: Pairing> GenericSRS<E> {
             n,
         };
         let vk = VerifierSRS::<E> {
-            n: n,
+            n,
             g: self.g_alpha_powers[0].into_group(),
             h: self.h_alpha_powers[0].into_group(),
             g_alpha: self.g_alpha_powers[1].into_group(),

--- a/src/srs.rs
+++ b/src/srs.rs
@@ -219,15 +219,15 @@ impl<E: Pairing> GenericSRS<E> {
     }
 
     pub fn read<R: Read>(mut reader: R) -> Result<Self, Error> {
-        let len = u32::deserialize_compressed(&mut reader).map_err(|e| Error::Serialization(e))?;
+        let len = u32::deserialize_compressed(&mut reader).map_err(Error::Serialization)?;
         if len > MAX_SRS_SIZE as u32 {
             return Err(Error::InvalidSRS("SRS len > maximum".to_string()));
         }
 
-        let g_alpha_powers = read_vec(len, &mut reader).map_err(|e| Error::Serialization(e))?;
-        let g_beta_powers = read_vec(len, &mut reader).map_err(|e| Error::Serialization(e))?;
-        let h_alpha_powers = read_vec(len, &mut reader).map_err(|e| Error::Serialization(e))?;
-        let h_beta_powers = read_vec(len, &mut reader).map_err(|e| Error::Serialization(e))?;
+        let g_alpha_powers = read_vec(len, &mut reader).map_err(Error::Serialization)?;
+        let g_beta_powers = read_vec(len, &mut reader).map_err(Error::Serialization)?;
+        let h_alpha_powers = read_vec(len, &mut reader).map_err(Error::Serialization)?;
+        let h_beta_powers = read_vec(len, &mut reader).map_err(Error::Serialization)?;
 
         Ok(Self {
             g_alpha_powers,

--- a/src/srs.rs
+++ b/src/srs.rs
@@ -301,7 +301,7 @@ pub(crate) fn structured_generators_scalar_power<G: CurveGroup>(
     }
     let scalar_bits = G::ScalarField::MODULUS_BIT_SIZE as usize;
     let window_size = FixedBase::get_mul_window_size(num);
-    let g_table = FixedBase::get_window_table::<G>(scalar_bits, window_size, g.clone());
+    let g_table = FixedBase::get_window_table::<G>(scalar_bits, window_size, *g);
     let powers_of_g = FixedBase::msm::<G>(
         //let powers_of_g = msm::fixed_base::multi_scalar_mul::<G>(
         scalar_bits,

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -37,7 +37,7 @@ impl Transcript for Merlin {
         loop {
             match F::from_random_bytes(&buf) {
                 Some(e) => {
-                    if let Some(_) = e.inverse() {
+                    if e.inverse().is_some() {
                         return e;
                     } else {
                         continue;

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -173,7 +173,7 @@ pub fn verify_aggregate_proof<E: Pairing + std::fmt::Debug, R: Rng + Send, T: Tr
 
                     g_ic.add_assign(&totsi);
 
-                    let ml = E::miller_loop(E::G1Prepared::from(g_ic.into_affine()), E::G2Prepared::from(pvk.vk.gamma_g2.clone()));
+                    let ml = E::miller_loop(E::G1Prepared::from(g_ic.into_affine()), E::G2Prepared::from(pvk.vk.gamma_g2));
                     let elapsed = now.elapsed().as_millis();
                     dbg!("table generation: {}ms", elapsed);
 
@@ -182,8 +182,7 @@ pub fn verify_aggregate_proof<E: Pairing + std::fmt::Debug, R: Rng + Send, T: Tr
         };
         // final value ip_ab is what we want to compare in the groth16
         // aggregated equation A * B
-        let check =
-            PairingCheck::from_products(vec![left.0, middle.0, right.0], proof.ip_ab.clone());
+        let check = PairingCheck::from_products(vec![left.0, middle.0, right.0], proof.ip_ab);
         send_checks.send(check).unwrap();
     });
     let res = valid_rcv.recv().unwrap();
@@ -285,7 +284,7 @@ fn verify_tipp_mipp<E: Pairing, R: Rng + Send, T: Transcript + Send>(
         // Verify base inner product commitment
         // Z ==  c ^ r
         let final_z =
-            ip::multiexponentiation::<E::G1Affine>(&[final_c.clone()], &[final_r]),
+            ip::multiexponentiation::<E::G1Affine>(&[*final_c], &[final_r]),
         // Check commiment correctness
         // T = e(C,v1)
         //let _check_t = tclone.send(PairingCheck::rand(&rng,&[(final_c,&fvkey.0)],final_tc)).unwrap(),
@@ -332,6 +331,7 @@ fn verify_tipp_mipp<E: Pairing, R: Rng + Send, T: Transcript + Send>(
 /// * There are T,U,Z vectors as well for the MIPP relationship. Both TIPP and
 /// MIPP share the same challenges however, enabling to re-use common operations
 /// between them, such as the KZG proof for commitment keys.
+#[allow(clippy::type_complexity)]
 fn gipa_verify_tipp_mipp<E: Pairing, T: Transcript + Send>(
     proof: &AggregateProof<E>,
     r_shift: &E::ScalarField,
@@ -429,6 +429,7 @@ fn gipa_verify_tipp_mipp<E: Pairing, T: Transcript + Send>(
     // Since at the end we want to multiple all "t" values together, we do
     // multiply all of them in parrallel and then merge then back at the end.
     // same for u and z.
+    #[allow(clippy::upper_case_acronyms)]
     enum Op<'a, E: Pairing> {
         TAB(
             &'a <E as Pairing>::TargetField,
@@ -562,7 +563,7 @@ pub fn verify_kzg_v<E: Pairing, R: Rng + Send>(
     // -g such that when we test a pairing equation we only need to check if
     // it's equal 1 at the end:
     // e(a,b) = e(c,d) <=> e(a,b)e(-c,d) = 1
-    let mut ng = v_srs.g.clone();
+    let mut ng = v_srs.g;
     // e(A,B) = e(C,D) <=> e(A,B)e(-C,D) == 1 <=> e(A,B)e(C,D)^-1 == 1
     ng = ng.neg();
     let ng = ng.into_affine();
@@ -599,6 +600,7 @@ pub fn verify_kzg_v<E: Pairing, R: Rng + Send>(
     };
 }
 
+#[allow(clippy::too_many_arguments)]
 fn kzg_check_v<E: Pairing, R: Rng + Send>(
     v_srs: &VerifierSRS<E>,
     ng: E::G1Affine,
@@ -628,6 +630,7 @@ fn kzg_check_v<E: Pairing, R: Rng + Send>(
 }
 
 /// Similar to verify_kzg_opening_g2 but for g1.
+#[allow(clippy::too_many_arguments)]
 pub fn verify_kzg_w<E: Pairing, R: Rng + Send>(
     v_srs: &VerifierSRS<E>,
     final_wkey: &(E::G1Affine, E::G1Affine),
@@ -682,6 +685,7 @@ pub fn verify_kzg_w<E: Pairing, R: Rng + Send>(
     };
 }
 
+#[allow(clippy::too_many_arguments)]
 fn kzg_check_w<E: Pairing, R: Rng + Send>(
     v_srs: &VerifierSRS<E>,
     nh: E::G2Affine,

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -196,6 +196,7 @@ pub fn verify_aggregate_proof<E: Pairing + std::fmt::Debug, R: Rng + Send, T: Tr
 /// verify_tipp_mipp returns a pairing equation to check the tipp proof.  $r$ is
 /// the randomness used to produce a random linear combination of A and B and
 /// used in the MIPP part with C
+#[allow(clippy::redundant_clone)]
 fn verify_tipp_mipp<E: Pairing, R: Rng + Send, T: Transcript + Send>(
     v_srs: &VerifierSRS<E>,
     proof: &AggregateProof<E>,
@@ -355,7 +356,7 @@ fn gipa_verify_tipp_mipp<E: Pairing, T: Transcript + Send>(
     let now = Instant::now();
 
     let mut challenges = Vec::new();
-    let mut challenges_inv = Vec::new();
+    let mut challenges_inv: Vec<<E as Pairing>::ScalarField> = Vec::new();
 
     transcript.append(b"inner-product-ab", &proof.ip_ab);
     transcript.append(b"comm-c", &proof.agg_c);
@@ -545,6 +546,7 @@ fn gipa_verify_tipp_mipp<E: Pairing, T: Transcript + Send>(
 /// verify_kzg_opening_g2 takes a KZG opening, the final commitment key, SRS and
 /// any shift (in TIPP we shift the v commitment by r^-1) and returns a pairing
 /// tuple to check if the opening is correct or not.
+#[allow(clippy::redundant_clone)]
 pub fn verify_kzg_v<E: Pairing, R: Rng + Send>(
     v_srs: &VerifierSRS<E>,
     final_vkey: &(E::G2Affine, E::G2Affine),
@@ -631,6 +633,7 @@ fn kzg_check_v<E: Pairing, R: Rng + Send>(
 
 /// Similar to verify_kzg_opening_g2 but for g1.
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::redundant_clone)]
 pub fn verify_kzg_w<E: Pairing, R: Rng + Send>(
     v_srs: &VerifierSRS<E>,
     final_wkey: &(E::G1Affine, E::G1Affine),


### PR DESCRIPTION
- fixes most of the clippy warnings
- disables some warnings about complex types or too many arguments in par with the bellperson crate
- also disables the wrongly linted clones in the verifyer to which issue https://github.com/nikkolasg/snarkpack/issues/6 is related.
- configure the CI to deny clippy warnings

Let's test the benchmarking bot :)